### PR TITLE
Support no data alpha transparent and fix domain range error

### DIFF
--- a/dist/leaflet-geotiff-plotty.js
+++ b/dist/leaflet-geotiff-plotty.js
@@ -13,7 +13,8 @@
       clampLow: true,
       clampHigh: true,
       displayMin: 0,
-      displayMax: 1
+      displayMax: 1,
+      noDataValue: -9999,
     },
     initialize: function initialize(options) {
       if (typeof plotty === "undefined") {
@@ -89,7 +90,7 @@
         canvas: plottyCanvas,
         useWebGL: false
       });
-      plot.setNoDataValue(-9999);
+      plot.setNoDataValue(this.options.noDataValue);
       plot.render();
       this.colorScaleData = plot.colorScaleCanvas.toDataURL();
       var rasterImageData = plottyCanvas.getContext("2d").getImageData(0, 0, plottyCanvas.width, plottyCanvas.height);

--- a/dist/leaflet-geotiff-plotty.js
+++ b/dist/leaflet-geotiff-plotty.js
@@ -69,7 +69,7 @@
         data: [0],
         width: 1,
         height: 1,
-        domain: [this.options.displayMin, this.options.displayMax + 1],
+        domain: [this.options.displayMin, this.options.displayMax],
         colorScale: this.options.colorScale,
         clampLow: this.options.clampLow,
         clampHigh: this.options.clampHigh
@@ -83,7 +83,7 @@
         // fix for use with rgb conversion (appending alpha channel)
         width: raster.width,
         height: raster.height,
-        domain: [this.options.displayMin, this.options.displayMax + 1],
+        domain: [this.options.displayMin, this.options.displayMax],
         colorScale: this.options.colorScale,
         clampLow: this.options.clampLow,
         clampHigh: this.options.clampHigh,

--- a/src/leaflet-geotiff-plotty.js
+++ b/src/leaflet-geotiff-plotty.js
@@ -68,7 +68,7 @@ L.LeafletGeotiff.Plotty = L.LeafletGeotiffRenderer.extend({
       data: [0],
       width: 1,
       height: 1,
-      domain: [this.options.displayMin, this.options.displayMax + 1],
+      domain: [this.options.displayMin, this.options.displayMax],
       colorScale: this.options.colorScale,
       clampLow: this.options.clampLow,
       clampHigh: this.options.clampHigh
@@ -82,7 +82,7 @@ L.LeafletGeotiff.Plotty = L.LeafletGeotiffRenderer.extend({
       data: raster.data[0], // fix for use with rgb conversion (appending alpha channel)
       width: raster.width,
       height: raster.height,
-      domain: [this.options.displayMin, this.options.displayMax + 1],
+      domain: [this.options.displayMin, this.options.displayMax],
       colorScale: this.options.colorScale,
       clampLow: this.options.clampLow,
       clampHigh: this.options.clampHigh,

--- a/src/leaflet-geotiff-plotty.js
+++ b/src/leaflet-geotiff-plotty.js
@@ -89,7 +89,7 @@ L.LeafletGeotiff.Plotty = L.LeafletGeotiffRenderer.extend({
       canvas: plottyCanvas,
       useWebGL: false
     });
-    plot.setNoDataValue(this.noDataValue);
+    plot.setNoDataValue(this.options.noDataValue);
     plot.render();
 
     this.colorScaleData = plot.colorScaleCanvas.toDataURL();

--- a/src/leaflet-geotiff-plotty.js
+++ b/src/leaflet-geotiff-plotty.js
@@ -9,7 +9,8 @@ L.LeafletGeotiff.Plotty = L.LeafletGeotiffRenderer.extend({
     clampLow: true,
     clampHigh: true,
     displayMin: 0,
-    displayMax: 1
+    displayMax: 1,
+    noDataValue: -9999,
   },
 
   initialize: function(options) {
@@ -88,7 +89,7 @@ L.LeafletGeotiff.Plotty = L.LeafletGeotiffRenderer.extend({
       canvas: plottyCanvas,
       useWebGL: false
     });
-    plot.setNoDataValue(-9999);
+    plot.setNoDataValue(this.noDataValue);
     plot.render();
 
     this.colorScaleData = plot.colorScaleCanvas.toDataURL();


### PR DESCRIPTION
Added a parameter noDataValue in plotty renderer, to setup a value to leave with 0 opacity.