### PR TITLE
Added WebGL support to Plotty renderer

### DIFF
--- a/src/leaflet-geotiff-plotty.js
+++ b/src/leaflet-geotiff-plotty.js
@@ -104,7 +104,7 @@ L.LeafletGeotiff.Plotty = L.LeafletGeotiffRenderer.extend({
       clampHigh: this.options.clampHigh,
       canvas: plottyCanvas,
       matrix: matrixTransform,
-      useWebGL: false
+      useWebGL: this.options.useWebGL
     });
     plot.setNoDataValue(this.options.noDataValue);
     plot.render();


### PR DESCRIPTION
An option to GeoTIFF Plotty is added to make use of WebGL if available.
It takes care of geometric transformations and it is used in the exact same way than before.